### PR TITLE
Normalize email handling for authentication

### DIFF
--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -14,10 +14,12 @@ class RegisterController extends Controller
 {
     public function store(RegisterRequest $request): JsonResponse
     {
+        $data = $request->validated();
+
         $user = User::create([
-            'name'     => $request->input('name'),
-            'email'    => $request->input('email'),
-            'password' => Hash::make($request->input('password')),
+            'name'     => $data['name'],
+            'email'    => $data['email'],
+            'password' => Hash::make($data['password']),
         ]);
 
         event(new Registered($user));

--- a/app/Http/Controllers/Auth/SessionController.php
+++ b/app/Http/Controllers/Auth/SessionController.php
@@ -14,6 +14,12 @@ class SessionController extends Controller
 {
     public function login(Request $request): JsonResponse
     {
+        if (is_string($email = $request->input('email'))) {
+            $request->merge([
+                'email' => str($email)->trim()->lower()->toString(),
+            ]);
+        }
+
         $validated = $request->validate([
             'email'    => ['required', 'email'],
             'password' => ['required', 'string'],

--- a/app/Http/Controllers/Auth/TokenController.php
+++ b/app/Http/Controllers/Auth/TokenController.php
@@ -4,15 +4,11 @@ namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\Auth\LoginPasswordRequest;
-
 use App\Models\User;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Http\JsonResponse;
-
-use Illuminate\Contracts\Auth\MustVerifyEmail;
-use Illuminate\Support\Facades\Auth;
-
 use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Hash;
 use Illuminate\Validation\ValidationException;
 
@@ -23,7 +19,7 @@ class TokenController extends Controller
      */
     public function store(LoginPasswordRequest $request): JsonResponse
     {
-        $credentials = $request->only('email','password');
+        $credentials = $request->safe()->only(['email', 'password']);
 
         /** @var \App\Models\User|null $user */
         $user = User::query()->where('email', $credentials['email'])->first();

--- a/app/Http/Requests/Auth/LoginPasswordRequest.php
+++ b/app/Http/Requests/Auth/LoginPasswordRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 
 class LoginPasswordRequest extends FormRequest
 {
@@ -18,5 +19,14 @@ class LoginPasswordRequest extends FormRequest
             'password' => ['required','string'],
             'device_name' => ['sometimes','string','max:120'],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (is_string($email = $this->input('email'))) {
+            $this->merge([
+                'email' => Str::of($email)->trim()->lower()->toString(),
+            ]);
+        }
     }
 }

--- a/app/Http/Requests/Auth/RegisterRequest.php
+++ b/app/Http/Requests/Auth/RegisterRequest.php
@@ -3,6 +3,7 @@
 namespace App\Http\Requests\Auth;
 
 use Illuminate\Foundation\Http\FormRequest;
+use Illuminate\Support\Str;
 use Illuminate\Validation\Rules\Password;
 
 class RegisterRequest extends FormRequest
@@ -19,5 +20,14 @@ class RegisterRequest extends FormRequest
             'email' => ['required', 'email', 'max:255', 'unique:users,email'],
             'password' => ['required', Password::defaults()],
         ];
+    }
+
+    protected function prepareForValidation(): void
+    {
+        if (is_string($email = $this->input('email'))) {
+            $this->merge([
+                'email' => Str::of($email)->trim()->lower()->toString(),
+            ]);
+        }
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -25,7 +25,7 @@ class UserFactory extends Factory
     {
         return [
             'name' => fake()->name(),
-            'email' => fake()->unique()->safeEmail(),
+            'email' => Str::lower(fake()->unique()->safeEmail()),
             'email_verified_at' => now(),
             'password' => static::$password ??= Hash::make('password'),
             'remember_token' => Str::random(10),

--- a/database/migrations/2025_09_23_034100_enforce_case_insensitive_unique_emails.php
+++ b/database/migrations/2025_09_23_034100_enforce_case_insensitive_unique_emails.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('users', function (Blueprint $table) {
+            $table->dropUnique('users_email_unique');
+        });
+
+        DB::statement('CREATE UNIQUE INDEX users_email_lower_unique ON users (LOWER(email));');
+    }
+
+    public function down(): void
+    {
+        DB::statement('DROP INDEX IF EXISTS users_email_lower_unique;');
+
+        Schema::table('users', function (Blueprint $table) {
+            $table->unique('email');
+        });
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -5,6 +5,7 @@ namespace Database\Seeders;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
+use Illuminate\Support\Str;
 
 class DatabaseSeeder extends Seeder
 {
@@ -17,7 +18,7 @@ class DatabaseSeeder extends Seeder
 
         User::factory()->create([
             'name' => 'Test User',
-            'email' => 'test@example.com',
+            'email' => Str::lower('test@example.com'),
         ]);
     }
 }

--- a/tests/Feature/Auth/SecureAuthenticationTest.php
+++ b/tests/Feature/Auth/SecureAuthenticationTest.php
@@ -30,6 +30,23 @@ class SecureAuthenticationTest extends TestCase
         Notification::assertSentTo($user, VerifyEmail::class);
     }
 
+    public function test_registration_normalizes_mixed_case_email(): void
+    {
+        Notification::fake();
+
+        $response = $this->postJson('/api/auth/register', [
+            'name' => 'Janet Doe',
+            'email' => ' Mixed.Case@Example.COM ',
+            'password' => 'Str0ngP@ssword!',
+        ]);
+
+        $response->assertCreated();
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'mixed.case@example.com',
+        ]);
+    }
+
     public function test_session_login_requires_verified_email(): void
     {
         $user = User::factory()->unverified()->create([
@@ -56,6 +73,24 @@ class SecureAuthenticationTest extends TestCase
 
         $response = $this->postJson('/api/auth/session/login', [
             'email' => $user->email,
+            'password' => 'Secret123!',
+        ]);
+
+        $response
+            ->assertOk()
+            ->assertJsonPath('data.id', $user->id)
+            ->assertJsonPath('meta.message', 'Session login OK');
+    }
+
+    public function test_session_login_accepts_mixed_case_email(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'casey@example.com',
+            'password' => bcrypt('Secret123!'),
+        ]);
+
+        $response = $this->postJson('/api/auth/session/login', [
+            'email' => '  Casey@Example.COM ',
             'password' => 'Secret123!',
         ]);
 
@@ -104,6 +139,24 @@ class SecureAuthenticationTest extends TestCase
             'tokenable_id' => $user->id,
             'tokenable_type' => User::class,
         ]);
+    }
+
+    public function test_token_login_accepts_mixed_case_email(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'token@example.com',
+            'password' => bcrypt('Secret123!'),
+        ]);
+
+        $response = $this->postJson('/api/auth/tokens', [
+            'email' => ' Token@Example.COM ',
+            'password' => 'Secret123!',
+            'device_name' => 'phpunit',
+        ]);
+
+        $response
+            ->assertCreated()
+            ->assertJsonStructure(['token']);
     }
 
     public function test_secure_routes_require_authentication(): void


### PR DESCRIPTION
## Summary
- normalize authentication request emails before validation and authentication attempts
- persist sanitized addresses, update seeds/factories, and enforce case-insensitive uniqueness at the database layer
- add feature tests confirming mixed-case registration and logins succeed

## Testing
- php artisan test
