### PR TITLE
Add registration rate limiting and tests

### DIFF
--- a/app/Providers/FortifyServiceProvider.php
+++ b/app/Providers/FortifyServiceProvider.php
@@ -41,6 +41,13 @@ class FortifyServiceProvider extends ServiceProvider
             return Limit::perMinute(5)->by($throttleKey);
         });
 
+        RateLimiter::for('register', function (Request $request) {
+            $email = Str::lower((string) $request->input('email', ''));
+            $throttleKey = Str::transliterate($email.'|'.$request->ip());
+
+            return Limit::perMinute(5)->by($throttleKey);
+        });
+
         RateLimiter::for('two-factor', function (Request $request) {
             return Limit::perMinute(5)->by($request->session()->get('login.id'));
         });

--- a/routes/api.php
+++ b/routes/api.php
@@ -16,7 +16,9 @@ Route::get('/health', fn () => ['ok' => true])->name('health');
 // Public auth endpoints
 Route::prefix('auth')->group(function () {
     // Registration + login
-    Route::post('/register', [RegisterController::class, 'store'])->name('auth.register');
+    Route::post('/register', [RegisterController::class, 'store'])
+        ->middleware(['throttle:register'])
+        ->name('auth.register');
     Route::post('/login', [LoginController::class, 'password'])
         ->middleware(['throttle:login', 'web'])
         ->name('auth.login');

--- a/tests/Feature/Auth/SecureAuthenticationTest.php
+++ b/tests/Feature/Auth/SecureAuthenticationTest.php
@@ -30,6 +30,25 @@ class SecureAuthenticationTest extends TestCase
         Notification::assertSentTo($user, VerifyEmail::class);
     }
 
+    public function test_registration_is_rate_limited_after_five_attempts(): void
+    {
+        $payload = [
+            'name' => 'Rate Limited',
+            'email' => 'limited@example.com',
+            'password' => 'Str0ngP@ssword!',
+        ];
+
+        for ($attempt = 0; $attempt < 5; $attempt++) {
+            $response = $this->postJson('/api/auth/register', $payload);
+
+            $attempt === 0
+                ? $response->assertCreated()
+                : $response->assertStatus(422);
+        }
+
+        $this->postJson('/api/auth/register', $payload)->assertStatus(429);
+    }
+
     public function test_session_login_requires_verified_email(): void
     {
         $user = User::factory()->unverified()->create([


### PR DESCRIPTION
## Summary
- add a Fortify rate limiter for registration attempts keyed by email and IP
- apply the custom register throttle middleware to the API registration route
- cover the throttling behaviour with a feature test that asserts a 429 response after the limit is exceeded

## Testing
- php artisan test --filter=SecureAuthenticationTest *(fails: Class "Laravel\\Fortify\\Features" not found)*
