### PR TITLE
Add notification for magic link emails

### DIFF
--- a/app/Notifications/MagicLinkNotification.php
+++ b/app/Notifications/MagicLinkNotification.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace App\Notifications;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Notifications\Messages\MailMessage;
+use Illuminate\Notifications\Notification;
+
+class MagicLinkNotification extends Notification implements ShouldQueue
+{
+    use Queueable;
+
+    /**
+     * Create a new notification instance.
+     */
+    public function __construct(
+        protected string $url,
+    ) {
+    }
+
+    /**
+     * Get the notification's delivery channels.
+     *
+     * @return array<int, string>
+     */
+    public function via(object $notifiable): array
+    {
+        return ['mail'];
+    }
+
+    /**
+     * Get the mail representation of the notification.
+     */
+    public function toMail(object $notifiable): MailMessage
+    {
+        return (new MailMessage())
+            ->subject('Your magic link to access the application')
+            ->line('Use the secure button below to finish signing in.')
+            ->action('Access your account', $this->url)
+            ->line('If the button does not work, copy and paste this link into your browser:')
+            ->line($this->url);
+    }
+}

--- a/tests/Unit/MagicLinkNotificationTest.php
+++ b/tests/Unit/MagicLinkNotificationTest.php
@@ -1,0 +1,24 @@
+<?php
+
+namespace Tests\Unit;
+
+use App\Notifications\MagicLinkNotification;
+use Illuminate\Notifications\Messages\MailMessage;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class MagicLinkNotificationTest extends TestCase
+{
+    #[Test]
+    public function it_renders_the_action_url(): void
+    {
+        $url = 'https://example.com/magic-link?token=secret';
+
+        $notification = new MagicLinkNotification($url);
+
+        $mailMessage = $notification->toMail((object) []);
+
+        $this->assertInstanceOf(MailMessage::class, $mailMessage);
+        $this->assertSame($url, $mailMessage->actionUrl);
+    }
+}


### PR DESCRIPTION
## Summary
- add a queued magic link notification that delivers a mail message with actionable and fallback content
- cover the notification with a unit test that verifies the generated action URL

## Testing
- php artisan test --testsuite=Unit

------
https://chatgpt.com/codex/tasks/task_e_68d857f1f9108329a456e537795bd071