### PR TITLE
Add magic login token model, migration, and factory

### DIFF
--- a/app/Models/MagicLoginToken.php
+++ b/app/Models/MagicLoginToken.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+/** @use HasFactory<\Database\Factories\MagicLoginTokenFactory> */
+class MagicLoginToken extends Model
+{
+    use HasFactory;
+
+    /**
+     * Indicates if the IDs are auto-incrementing.
+     */
+    public $incrementing = false;
+
+    /**
+     * The data type of the primary key ID.
+     */
+    protected $keyType = 'string';
+
+    /**
+     * The attributes that are mass assignable.
+     *
+     * @var list<string>
+     */
+    protected $fillable = [
+        'id',
+        'user_id',
+        'token_hash',
+        'expires_at',
+        'used_at',
+        'ip',
+        'user_agent',
+        'used_ip',
+        'used_ua',
+        'remember',
+        'redirect_to',
+    ];
+
+    /**
+     * The attributes that should be cast.
+     *
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'expires_at' => 'datetime',
+        'used_at' => 'datetime',
+        'remember' => 'boolean',
+    ];
+
+    /**
+     * Get the user that owns the token.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,6 +5,7 @@ namespace App\Models;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\HasMany;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
@@ -46,5 +47,13 @@ class User extends Authenticatable implements MustVerifyEmail
             'email_verified_at' => 'datetime',
             'password' => 'hashed',
         ];
+    }
+
+    /**
+     * Get the magic login tokens associated with the user.
+     */
+    public function magicLoginTokens(): HasMany
+    {
+        return $this->hasMany(MagicLoginToken::class);
     }
 }

--- a/database/factories/MagicLoginTokenFactory.php
+++ b/database/factories/MagicLoginTokenFactory.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Database\Factories;
+
+use App\Models\MagicLoginToken;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Str;
+
+/**
+ * @extends Factory<MagicLoginToken>
+ */
+class MagicLoginTokenFactory extends Factory
+{
+    protected $model = MagicLoginToken::class;
+
+    public function definition(): array
+    {
+        $plain = Str::random(64);
+
+        return [
+            'id' => (string) Str::ulid(),
+            'user_id' => User::factory(),
+            'token_hash' => hash('sha256', $plain),
+            'expires_at' => now()->addMinutes(15),
+            'remember' => $this->faker->boolean(),
+            'redirect_to' => $this->faker->boolean(30) ? $this->faker->url() : null,
+            'ip' => $this->faker->ipv4(),
+            'user_agent' => $this->faker->userAgent(),
+        ];
+    }
+
+    public function used(): static
+    {
+        return $this->state(function () {
+            return [
+                'used_at' => now(),
+                'used_ip' => $this->faker->ipv4(),
+                'used_ua' => $this->faker->userAgent(),
+            ];
+        });
+    }
+}

--- a/database/migrations/2025_09_23_034100_create_magic_login_tokens_table.php
+++ b/database/migrations/2025_09_23_034100_create_magic_login_tokens_table.php
@@ -1,0 +1,40 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('magic_login_tokens', function (Blueprint $table) {
+            $table->ulid('id')->primary();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('token_hash', 128);
+            $table->timestamp('expires_at');
+            $table->timestamp('used_at')->nullable();
+            $table->boolean('remember')->default(false);
+            $table->string('redirect_to', 2048)->nullable();
+            $table->ipAddress('ip')->nullable();
+            $table->string('user_agent')->nullable();
+            $table->ipAddress('used_ip')->nullable();
+            $table->string('used_ua')->nullable();
+            $table->timestamps();
+
+            $table->index('expires_at');
+            $table->index('used_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('magic_login_tokens');
+    }
+};


### PR DESCRIPTION
## Summary
- add a MagicLoginToken model with the expected relationship, fillable attributes, and casts
- create the magic_login_tokens migration with a ULID key, hashed token, and audit metadata
- provide a factory and user relationship to simplify testing and maintenance

## Testing
- php artisan test *(fails: Class "Laravel\\Fortify\\Features" not found)*

------
https://chatgpt.com/codex/tasks/task_e_68d857e5f3d88329bdf1c37593fcd791