### PR TITLE
Add authorization roles management and tests

### DIFF
--- a/app/Http/Controllers/Admin/PermissionController.php
+++ b/app/Http/Controllers/Admin/PermissionController.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Permission;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class PermissionController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $permissions = Permission::orderBy('name')->get();
+
+        return response()->json($permissions);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:191', 'unique:permissions,name'],
+            'display_name' => ['nullable', 'string', 'max:191'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $permission = Permission::create($data);
+
+        return response()->json($permission, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Permission $permission): JsonResponse
+    {
+        return response()->json($permission);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Permission $permission): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => ['sometimes', 'string', 'max:191', Rule::unique('permissions', 'name')->ignore($permission->id)],
+            'display_name' => ['nullable', 'string', 'max:191'],
+            'description' => ['nullable', 'string', 'max:500'],
+        ]);
+
+        $permission->fill($data);
+        $permission->save();
+
+        return response()->json($permission);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Permission $permission): Response
+    {
+        $permission->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Admin/ProfileController.php
+++ b/app/Http/Controllers/Admin/ProfileController.php
@@ -1,0 +1,82 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Profile;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class ProfileController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $profiles = Profile::with('user')->orderBy('id')->get();
+
+        return response()->json($profiles);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatedData($request);
+
+        $profile = Profile::create($data);
+
+        return response()->json($profile->load('user'), 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Profile $profile): JsonResponse
+    {
+        return response()->json($profile->load('user'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Profile $profile): JsonResponse
+    {
+        $data = $this->validatedData($request, $profile->id, $profile->user_id);
+
+        $profile->fill($data);
+        $profile->save();
+
+        return response()->json($profile->load('user'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Profile $profile): Response
+    {
+        $profile->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Validate profile payload.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validatedData(Request $request, ?int $profileId = null, ?int $userId = null): array
+    {
+        return $request->validate([
+            'user_id' => [$profileId ? 'sometimes' : 'required', 'integer', Rule::exists('users', 'id'), Rule::unique('profiles', 'user_id')->ignore($userId, 'user_id')],
+            'first_name' => ['nullable', 'string', 'max:191'],
+            'last_name' => ['nullable', 'string', 'max:191'],
+            'phone' => ['nullable', 'string', 'max:50'],
+            'meta' => ['nullable', 'array'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/RoleController.php
+++ b/app/Http/Controllers/Admin/RoleController.php
@@ -1,0 +1,87 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Role;
+use Illuminate\Support\Arr;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class RoleController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $roles = Role::with('permissions')->orderBy('name')->get();
+
+        return response()->json($roles);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => ['required', 'string', 'max:191', 'unique:roles,name'],
+            'display_name' => ['nullable', 'string', 'max:191'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'permissions' => ['nullable', 'array'],
+            'permissions.*' => ['integer', Rule::exists('permissions', 'id')],
+        ]);
+
+        $role = Role::create(Arr::except($data, ['permissions']));
+
+        if (! empty($data['permissions'] ?? [])) {
+            $role->permissions()->sync($data['permissions']);
+        }
+
+        return response()->json($role->load('permissions'), 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Role $role): JsonResponse
+    {
+        return response()->json($role->load('permissions'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Role $role): JsonResponse
+    {
+        $data = $request->validate([
+            'name' => ['sometimes', 'string', 'max:191', Rule::unique('roles', 'name')->ignore($role->id)],
+            'display_name' => ['nullable', 'string', 'max:191'],
+            'description' => ['nullable', 'string', 'max:500'],
+            'permissions' => ['nullable', 'array'],
+            'permissions.*' => ['integer', Rule::exists('permissions', 'id')],
+        ]);
+
+        $role->fill(Arr::except($data, ['permissions']));
+        $role->save();
+
+        if (array_key_exists('permissions', $data)) {
+            $role->permissions()->sync($data['permissions'] ?? []);
+        }
+
+        return response()->json($role->load('permissions'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Role $role): Response
+    {
+        $role->delete();
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/Admin/SettingController.php
+++ b/app/Http/Controllers/Admin/SettingController.php
@@ -1,0 +1,78 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Setting;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class SettingController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        return response()->json(Setting::orderBy('key')->get());
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatedData($request);
+
+        $setting = Setting::create($data);
+
+        return response()->json($setting, 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Setting $setting): JsonResponse
+    {
+        return response()->json($setting);
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Setting $setting): JsonResponse
+    {
+        $data = $this->validatedData($request, $setting->id);
+
+        $setting->fill($data);
+        $setting->save();
+
+        return response()->json($setting);
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Setting $setting): Response
+    {
+        $setting->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Validate setting payload.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validatedData(Request $request, ?int $settingId = null): array
+    {
+        return $request->validate([
+            'key' => [$settingId ? 'sometimes' : 'required', 'string', 'max:191', Rule::unique('settings', 'key')->ignore($settingId)],
+            'value' => ['nullable'],
+            'type' => ['nullable', 'string', 'max:50'],
+        ]);
+    }
+}

--- a/app/Http/Controllers/Admin/TeamController.php
+++ b/app/Http/Controllers/Admin/TeamController.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Team;
+use Illuminate\Support\Arr;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class TeamController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $teams = Team::with('users')->orderBy('name')->get();
+
+        return response()->json($teams);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatedData($request);
+
+        $team = Team::create(Arr::only($data, ['name', 'description']));
+
+        $this->syncMembers($team, $data);
+
+        return response()->json($team->load('users'), 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(Team $team): JsonResponse
+    {
+        return response()->json($team->load('users'));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, Team $team): JsonResponse
+    {
+        $data = $this->validatedData($request, $team->id);
+
+        $team->fill(Arr::only($data, ['name', 'description']));
+        $team->save();
+
+        $this->syncMembers($team, $data);
+
+        return response()->json($team->load('users'));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(Team $team): Response
+    {
+        $team->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Validate request payload.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validatedData(Request $request, ?int $teamId = null): array
+    {
+        return $request->validate([
+            'name' => [$teamId ? 'sometimes' : 'required', 'string', 'max:191', Rule::unique('teams', 'name')->ignore($teamId)],
+            'description' => ['nullable', 'string', 'max:500'],
+            'members' => ['nullable', 'array'],
+            'members.*.id' => ['required', 'integer', Rule::exists('users', 'id')],
+            'members.*.role' => ['nullable', 'string', 'max:191'],
+        ]);
+    }
+
+    /**
+     * Sync members if provided.
+     */
+    protected function syncMembers(Team $team, array $data): void
+    {
+        if (array_key_exists('members', $data)) {
+            $payload = collect($data['members'] ?? [])
+                ->mapWithKeys(fn (array $member) => [$member['id'] => ['role' => $member['role'] ?? null]]);
+            $team->users()->sync($payload);
+        }
+    }
+}

--- a/app/Http/Controllers/Admin/UserController.php
+++ b/app/Http/Controllers/Admin/UserController.php
@@ -1,0 +1,142 @@
+<?php
+
+namespace App\Http\Controllers\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\User;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Validation\Rule;
+
+class UserController extends Controller
+{
+    /**
+     * Display a listing of the resource.
+     */
+    public function index(): JsonResponse
+    {
+        $users = User::with(['roles', 'teams', 'profile'])->orderBy('name')->get();
+
+        return response()->json($users);
+    }
+
+    /**
+     * Store a newly created resource in storage.
+     */
+    public function store(Request $request): JsonResponse
+    {
+        $data = $this->validatedData($request);
+
+        $user = User::create($this->extractUserAttributes($data));
+
+        $this->syncRelations($user, $data);
+
+        return response()->json($user->load(['roles', 'teams', 'profile']), 201);
+    }
+
+    /**
+     * Display the specified resource.
+     */
+    public function show(User $user): JsonResponse
+    {
+        return response()->json($user->load(['roles', 'teams', 'profile']));
+    }
+
+    /**
+     * Update the specified resource in storage.
+     */
+    public function update(Request $request, User $user): JsonResponse
+    {
+        $data = $this->validatedData($request, $user->id);
+
+        $user->fill($this->extractUserAttributes($data));
+
+        if (array_key_exists('password', $data)) {
+            $user->password = $data['password'];
+        }
+
+        $user->save();
+
+        $this->syncRelations($user, $data);
+
+        return response()->json($user->load(['roles', 'teams', 'profile']));
+    }
+
+    /**
+     * Remove the specified resource from storage.
+     */
+    public function destroy(User $user): Response
+    {
+        $user->delete();
+
+        return response()->noContent();
+    }
+
+    /**
+     * Validate incoming user payload.
+     *
+     * @return array<string, mixed>
+     */
+    protected function validatedData(Request $request, ?int $userId = null): array
+    {
+        return $request->validate([
+            'name' => [$userId ? 'sometimes' : 'required', 'string', 'max:191'],
+            'email' => [$userId ? 'sometimes' : 'required', 'email', 'max:191', Rule::unique('users', 'email')->ignore($userId)],
+            'password' => [$userId ? 'sometimes' : 'required', 'string', 'min:8'],
+            'roles' => ['nullable', 'array'],
+            'roles.*' => ['integer', Rule::exists('roles', 'id')],
+            'teams' => ['nullable', 'array'],
+            'teams.*.id' => ['required', 'integer', Rule::exists('teams', 'id')],
+            'teams.*.role' => ['nullable', 'string', 'max:191'],
+            'profile' => ['nullable', 'array'],
+            'profile.first_name' => ['nullable', 'string', 'max:191'],
+            'profile.last_name' => ['nullable', 'string', 'max:191'],
+            'profile.phone' => ['nullable', 'string', 'max:50'],
+            'profile.meta' => ['nullable', 'array'],
+        ]);
+    }
+
+    /**
+     * Sync related models (roles, teams, profile).
+     */
+    protected function syncRelations(User $user, array $data): void
+    {
+        if (array_key_exists('roles', $data)) {
+            $user->roles()->sync($data['roles'] ?? []);
+        }
+
+        if (array_key_exists('teams', $data)) {
+            $pivotData = collect($data['teams'] ?? [])
+                ->mapWithKeys(fn (array $team) => [$team['id'] => ['role' => $team['role'] ?? null]]);
+            $user->teams()->sync($pivotData);
+        }
+
+        if (array_key_exists('profile', $data)) {
+            if (! empty($data['profile'])) {
+                $user->profile()->updateOrCreate([], $data['profile']);
+            } else {
+                $user->profile()->delete();
+            }
+        }
+    }
+
+    /**
+     * Extract fillable user attributes from validated payload.
+     *
+     * @param array<string, mixed> $data
+     * @return array<string, mixed>
+     */
+    protected function extractUserAttributes(array $data): array
+    {
+        $attributes = [];
+
+        foreach (['name', 'email', 'password'] as $field) {
+            if (array_key_exists($field, $data)) {
+                $attributes[$field] = $data[$field];
+            }
+        }
+
+        return $attributes;
+    }
+}

--- a/app/Models/Permission.php
+++ b/app/Models/Permission.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Permission extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'display_name',
+        'description',
+    ];
+
+    /**
+     * Roles that have the permission.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)->withTimestamps();
+    }
+}

--- a/app/Models/Profile.php
+++ b/app/Models/Profile.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class Profile extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'user_id',
+        'first_name',
+        'last_name',
+        'phone',
+        'meta',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'meta' => 'array',
+    ];
+
+    /**
+     * User that owns the profile.
+     */
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class);
+    }
+}

--- a/app/Models/Role.php
+++ b/app/Models/Role.php
@@ -1,0 +1,37 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Role extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'display_name',
+        'description',
+    ];
+
+    /**
+     * Permissions that belong to the role.
+     */
+    public function permissions(): BelongsToMany
+    {
+        return $this->belongsToMany(Permission::class)->withTimestamps();
+    }
+
+    /**
+     * Users assigned to the role.
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)->withTimestamps();
+    }
+}

--- a/app/Models/Setting.php
+++ b/app/Models/Setting.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class Setting extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'key',
+        'value',
+        'type',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'value' => 'string',
+    ];
+}

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
+
+class Team extends Model
+{
+    use HasFactory;
+
+    /**
+     * @var list<string>
+     */
+    protected $fillable = [
+        'name',
+        'description',
+    ];
+
+    /**
+     * Users that belong to the team.
+     */
+    public function users(): BelongsToMany
+    {
+        return $this->belongsToMany(User::class)
+            ->withPivot(['role'])
+            ->withTimestamps();
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -5,9 +5,12 @@ namespace App\Models;
 use Illuminate\Auth\MustVerifyEmail as MustVerifyEmailTrait;
 use Illuminate\Contracts\Auth\MustVerifyEmail;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Database\Eloquent\Relations\HasOne;
 use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
+use Illuminate\Support\Collection;
 use Laravel\Sanctum\HasApiTokens;
 
 class User extends Authenticatable implements MustVerifyEmail
@@ -55,5 +58,51 @@ class User extends Authenticatable implements MustVerifyEmail
     public function magicLoginTokens(): HasMany
     {
         return $this->hasMany(MagicLoginToken::class);
+    }
+
+    /**
+     * Roles assigned to the user.
+     */
+    public function roles(): BelongsToMany
+    {
+        return $this->belongsToMany(Role::class)->withTimestamps();
+    }
+
+    /**
+     * Teams the user is a member of.
+     */
+    public function teams(): BelongsToMany
+    {
+        return $this->belongsToMany(Team::class)->withPivot(['role'])->withTimestamps();
+    }
+
+    /**
+     * Associated profile for the user.
+     */
+    public function profile(): HasOne
+    {
+        return $this->hasOne(Profile::class);
+    }
+
+    /**
+     * Retrieve all permissions derived from the assigned roles.
+     */
+    public function allPermissions(): Collection
+    {
+        return $this->roles()
+            ->with('permissions')
+            ->get()
+            ->flatMap->permissions
+            ->unique('id')
+            ->values();
+    }
+
+    /**
+     * Determine if the user has a given permission name.
+     */
+    public function hasPermission(string $permission): bool
+    {
+        return $this->allPermissions()
+            ->contains(fn (Permission $perm) => $perm->name === $permission);
     }
 }

--- a/database/migrations/2025_09_30_080850_create_roles_table.php
+++ b/database/migrations/2025_09_30_080850_create_roles_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('roles', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('display_name')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('roles');
+    }
+};

--- a/database/migrations/2025_09_30_080852_create_permissions_table.php
+++ b/database/migrations/2025_09_30_080852_create_permissions_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permissions', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('display_name')->nullable();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permissions');
+    }
+};

--- a/database/migrations/2025_09_30_080854_create_teams_table.php
+++ b/database/migrations/2025_09_30_080854_create_teams_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('teams', function (Blueprint $table) {
+            $table->id();
+            $table->string('name')->unique();
+            $table->string('description')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('teams');
+    }
+};

--- a/database/migrations/2025_09_30_080855_create_profiles_table.php
+++ b/database/migrations/2025_09_30_080855_create_profiles_table.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('profiles', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('first_name')->nullable();
+            $table->string('last_name')->nullable();
+            $table->string('phone')->nullable();
+            $table->json('meta')->nullable();
+            $table->timestamps();
+            $table->unique('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('profiles');
+    }
+};

--- a/database/migrations/2025_09_30_080857_create_settings_table.php
+++ b/database/migrations/2025_09_30_080857_create_settings_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('settings', function (Blueprint $table) {
+            $table->id();
+            $table->string('key')->unique();
+            $table->text('value')->nullable();
+            $table->string('type')->default('string');
+            $table->timestamps();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('settings');
+    }
+};

--- a/database/migrations/2025_09_30_080859_create_permission_role_table.php
+++ b/database/migrations/2025_09_30_080859_create_permission_role_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('permission_role', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('permission_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['permission_id', 'role_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('permission_role');
+    }
+};

--- a/database/migrations/2025_09_30_080901_create_role_user_table.php
+++ b/database/migrations/2025_09_30_080901_create_role_user_table.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('role_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('role_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->timestamps();
+            $table->unique(['role_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('role_user');
+    }
+};

--- a/database/migrations/2025_09_30_080903_create_team_user_table.php
+++ b/database/migrations/2025_09_30_080903_create_team_user_table.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('team_user', function (Blueprint $table) {
+            $table->id();
+            $table->foreignId('team_id')->constrained()->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained()->cascadeOnDelete();
+            $table->string('role')->nullable();
+            $table->timestamps();
+            $table->unique(['team_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('team_user');
+    }
+};

--- a/database/seeders/DatabaseSeeder.php
+++ b/database/seeders/DatabaseSeeder.php
@@ -2,6 +2,7 @@
 
 namespace Database\Seeders;
 
+use App\Models\Role;
 use App\Models\User;
 // use Illuminate\Database\Console\Seeds\WithoutModelEvents;
 use Illuminate\Database\Seeder;
@@ -14,11 +15,17 @@ class DatabaseSeeder extends Seeder
      */
     public function run(): void
     {
-        // User::factory(10)->create();
+        $this->call(RolePermissionSeeder::class);
 
-        User::factory()->create([
+        $user = User::factory()->create([
             'name' => 'Test User',
             'email' => Str::lower('test@example.com'),
         ]);
+
+        $managerRole = Role::where('name', 'manager')->first();
+
+        if ($managerRole) {
+            $user->roles()->sync([$managerRole->id]);
+        }
     }
 }

--- a/database/seeders/RolePermissionSeeder.php
+++ b/database/seeders/RolePermissionSeeder.php
@@ -1,0 +1,53 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\Permission;
+use App\Models\Role;
+use Illuminate\Database\Seeder;
+
+class RolePermissionSeeder extends Seeder
+{
+    /**
+     * Run the database seeds.
+     */
+    public function run(): void
+    {
+        $permissions = collect([
+            'read' => 'Permite visualizar recursos',
+            'write' => 'Permite crear nuevos recursos',
+            'delete' => 'Permite eliminar recursos',
+            'update' => 'Permite actualizar recursos',
+        ])->mapWithKeys(function (string $description, string $name) {
+            $permission = Permission::updateOrCreate(
+                ['name' => $name],
+                [
+                    'display_name' => ucfirst($name),
+                    'description' => $description,
+                ]
+            );
+
+            return [$name => $permission->id];
+        });
+
+        $rolePermissions = [
+            'client' => ['read'],
+            'support' => ['read', 'update'],
+            'manager' => ['read', 'update', 'write'],
+            'gerente' => ['read', 'update', 'write', 'delete'],
+            'subgerente' => ['read', 'update'],
+        ];
+
+        foreach ($rolePermissions as $roleName => $permissionNames) {
+            $role = Role::updateOrCreate(
+                ['name' => $roleName],
+                [
+                    'display_name' => ucfirst($roleName),
+                    'description' => 'Rol base: ' . $roleName,
+                ]
+            );
+
+            $role->permissions()->sync($permissions->only($permissionNames)->values()->all());
+        }
+    }
+}

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,6 +1,12 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\PermissionController;
+use App\Http\Controllers\Admin\ProfileController;
+use App\Http\Controllers\Admin\RoleController as AdminRoleController;
+use App\Http\Controllers\Admin\SettingController;
+use App\Http\Controllers\Admin\TeamController;
+use App\Http\Controllers\Admin\UserController as AdminUserController;
 use App\Http\Controllers\Auth\RegisterController;
 use App\Http\Controllers\Auth\LoginController;
 use App\Http\Controllers\Auth\SessionController;
@@ -33,8 +39,12 @@ Route::prefix('auth')->group(function () {
 
 
     // Magic link (stubs)
-    Route::post('/magic/request', [MagicLinkController::class, 'requestLink'])->name('auth.magic.request');
-    Route::post('/magic/verify', [MagicLinkController::class, 'verify'])->name('auth.magic.verify');
+    Route::post('/magic/request', [MagicLinkController::class, 'requestLink'])
+        ->middleware('web')
+        ->name('auth.magic.request');
+    Route::post('/magic/verify', [MagicLinkController::class, 'verify'])
+        ->middleware('web')
+        ->name('auth.magic.verify');
 
     // OAuth (stubs)
     Route::get('/oauth/redirect/{provider}', [OAuthController::class, 'redirect'])->name('auth.oauth.redirect');
@@ -69,6 +79,16 @@ Route::middleware('auth:sanctum')->group(function () {
             ->name('secure.logs');
         Route::get('/errors', [SecurePageController::class, 'errors'])
             ->name('secure.errors');
+    });
+
+    // Administrative CRUD endpoints
+    Route::prefix('admin')->group(function () {
+        Route::apiResource('roles', AdminRoleController::class);
+        Route::apiResource('permissions', PermissionController::class);
+        Route::apiResource('users', AdminUserController::class);
+        Route::apiResource('profiles', ProfileController::class);
+        Route::apiResource('teams', TeamController::class);
+        Route::apiResource('settings', SettingController::class);
     });
 });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -4,4 +4,4 @@ use Illuminate\Support\Facades\Route;
 
 Route::get('/', function () {
     return view('welcome');
-});
+})->name('home');

--- a/tests/Feature/AdminCrudTest.php
+++ b/tests/Feature/AdminCrudTest.php
@@ -1,0 +1,202 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\Permission;
+use App\Models\Role;
+use App\Models\Team;
+use App\Models\User;
+use Database\Seeders\RolePermissionSeeder;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Laravel\Sanctum\Sanctum;
+use Tests\TestCase;
+
+class AdminCrudTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected User $admin;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->seed(RolePermissionSeeder::class);
+
+        $this->admin = User::factory()->create([
+            'email' => 'admin@example.com',
+        ]);
+
+        $managerRole = Role::where('name', 'manager')->firstOrFail();
+        $this->admin->roles()->sync([$managerRole->id]);
+    }
+
+    public function test_roles_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $permissionId = Permission::where('name', 'read')->firstOrFail()->id;
+
+        $createResponse = $this->postJson('/api/admin/roles', [
+            'name' => 'auditor',
+            'display_name' => 'Auditor',
+            'description' => 'Reviews records',
+            'permissions' => [$permissionId],
+        ]);
+
+        $createResponse->assertCreated();
+
+        $roleId = $createResponse->json('id');
+
+        $this->getJson('/api/admin/roles')->assertJsonFragment(['name' => 'auditor']);
+
+        $this->putJson("/api/admin/roles/{$roleId}", [
+            'description' => 'Updated description',
+        ])->assertOk()->assertJsonFragment(['description' => 'Updated description']);
+
+        $this->deleteJson("/api/admin/roles/{$roleId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('roles', ['id' => $roleId]);
+    }
+
+    public function test_permission_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $createResponse = $this->postJson('/api/admin/permissions', [
+            'name' => 'archive',
+            'display_name' => 'Archive',
+        ]);
+
+        $createResponse->assertCreated();
+        $permissionId = $createResponse->json('id');
+
+        $this->getJson('/api/admin/permissions')->assertJsonFragment(['name' => 'archive']);
+
+        $this->putJson("/api/admin/permissions/{$permissionId}", [
+            'description' => 'Allows archiving',
+        ])->assertOk()->assertJsonFragment(['description' => 'Allows archiving']);
+
+        $this->deleteJson("/api/admin/permissions/{$permissionId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('permissions', ['id' => $permissionId]);
+    }
+
+    public function test_user_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $team = Team::create([
+            'name' => 'Core Team',
+            'description' => 'Main delivery team',
+        ]);
+
+        $roleId = Role::where('name', 'client')->firstOrFail()->id;
+
+        $createResponse = $this->postJson('/api/admin/users', [
+            'name' => 'API User',
+            'email' => 'api.user@example.com',
+            'password' => 'Password123!',
+            'roles' => [$roleId],
+            'teams' => [
+                ['id' => $team->id, 'role' => 'owner'],
+            ],
+            'profile' => [
+                'first_name' => 'API',
+                'last_name' => 'User',
+                'phone' => '+1-555-0000',
+                'meta' => ['timezone' => 'UTC'],
+            ],
+        ]);
+
+        $createResponse->assertCreated();
+        $userId = $createResponse->json('id');
+
+        $this->assertDatabaseHas('profiles', [
+            'user_id' => $userId,
+            'first_name' => 'API',
+        ]);
+
+        $this->putJson("/api/admin/users/{$userId}", [
+            'name' => 'Updated User',
+            'profile' => [],
+        ])->assertOk()->assertJsonFragment(['name' => 'Updated User']);
+
+        $this->deleteJson("/api/admin/users/{$userId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('users', ['id' => $userId]);
+    }
+
+    public function test_profile_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $user = User::factory()->create();
+
+        $createResponse = $this->postJson('/api/admin/profiles', [
+            'user_id' => $user->id,
+            'first_name' => 'Profile',
+            'last_name' => 'Owner',
+            'meta' => ['department' => 'QA'],
+        ]);
+
+        $createResponse->assertCreated();
+        $profileId = $createResponse->json('id');
+
+        $this->putJson("/api/admin/profiles/{$profileId}", [
+            'phone' => '1234567890',
+        ])->assertOk()->assertJsonFragment(['phone' => '1234567890']);
+
+        $this->deleteJson("/api/admin/profiles/{$profileId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('profiles', ['id' => $profileId]);
+    }
+
+    public function test_team_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $member = User::factory()->create();
+
+        $createResponse = $this->postJson('/api/admin/teams', [
+            'name' => 'Support Team',
+            'description' => 'Handles support tickets',
+            'members' => [
+                ['id' => $member->id, 'role' => 'support'],
+            ],
+        ]);
+
+        $createResponse->assertCreated();
+        $teamId = $createResponse->json('id');
+
+        $this->putJson("/api/admin/teams/{$teamId}", [
+            'description' => '24/7 Support',
+        ])->assertOk()->assertJsonFragment(['description' => '24/7 Support']);
+
+        $this->deleteJson("/api/admin/teams/{$teamId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('teams', ['id' => $teamId]);
+    }
+
+    public function test_setting_crud_flow(): void
+    {
+        Sanctum::actingAs($this->admin);
+
+        $createResponse = $this->postJson('/api/admin/settings', [
+            'key' => 'app.theme',
+            'value' => 'dark',
+            'type' => 'string',
+        ]);
+
+        $createResponse->assertCreated();
+        $settingId = $createResponse->json('id');
+
+        $this->putJson("/api/admin/settings/{$settingId}", [
+            'value' => 'light',
+        ])->assertOk()->assertJsonFragment(['value' => 'light']);
+
+        $this->deleteJson("/api/admin/settings/{$settingId}")->assertNoContent();
+
+        $this->assertDatabaseMissing('settings', ['id' => $settingId]);
+    }
+}

--- a/tests/Feature/AuthFeaturesTest.php
+++ b/tests/Feature/AuthFeaturesTest.php
@@ -1,0 +1,108 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Illuminate\Support\Facades\URL;
+use Tests\TestCase;
+
+class AuthFeaturesTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+    }
+
+    public function test_can_register_user_via_api(): void
+    {
+        $payload = [
+            'name' => 'New User',
+            'email' => 'new.user@example.com',
+            'password' => 'Password123!',
+        ];
+
+        $response = $this->postJson('/api/auth/register', $payload);
+
+        $response->assertCreated()
+            ->assertJsonPath('data.email', 'new.user@example.com');
+
+        $this->assertDatabaseHas('users', [
+            'email' => 'new.user@example.com',
+        ]);
+    }
+
+    public function test_can_login_with_verified_email(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'verified@example.com',
+            'password' => 'Password123!',
+        ]);
+
+        $response = $this->postJson('/api/auth/login', [
+            'email' => 'verified@example.com',
+            'password' => 'Password123!',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('data.email', 'verified@example.com');
+    }
+
+    public function test_can_request_password_reset_link(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create([
+            'email' => 'reset@example.com',
+        ]);
+
+        $response = $this->post('/forgot-password', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertSessionHas('status');
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    public function test_user_can_verify_email(): void
+    {
+        $user = User::factory()->unverified()->create([
+            'email' => 'verify.me@example.com',
+        ]);
+
+        $verificationUrl = URL::temporarySignedRoute(
+            'verification.verify',
+            now()->addMinutes(60),
+            ['id' => $user->id, 'hash' => sha1($user->email)]
+        );
+
+        $response = $this->actingAs($user)->get($verificationUrl);
+
+        $this->assertStringContainsString(
+            '/home',
+            $response->headers->get('Location')
+        );
+
+        $this->assertNotNull($user->fresh()->email_verified_at);
+    }
+
+    public function test_user_can_logout(): void
+    {
+        $user = User::factory()->create([
+            'email' => 'logout@example.com',
+        ]);
+
+        $response = $this->actingAs($user)->post('/logout');
+
+        $response->assertRedirect('/');
+        $this->assertGuest();
+    }
+}


### PR DESCRIPTION
## Summary
- add data models and migrations for roles, permissions, profiles, teams, and SaaS settings with seeded defaults
- expose authenticated admin API resources for managing roles, permissions, users, profiles, teams, and settings and update user relationships
- add feature coverage for core auth flows plus CRUD tests for administrative endpoints

## Testing
- php artisan test
