### PR TITLE
Document Next.js integration endpoints

### DIFF
--- a/docs/frontend-integration/admin-api/README.md
+++ b/docs/frontend-integration/admin-api/README.md
@@ -1,0 +1,81 @@
+# Protected & Admin API Reference
+
+Use this guide when wiring authenticated dashboards or admin screens from Next.js. All endpoints listed here require a valid Sanctum token or session cookie because they are wrapped in the `auth:sanctum` middleware group.【F:routes/api.php†L56-L94】
+
+## 1. Secure page data
+These endpoints power authenticated dashboard sections and return the current user plus section metadata.
+
+| Method & Path | Description | Sample meta payload |
+| --- | --- | --- |
+| `GET /api/secure/dashboard` | Dashboard summary gate. | `{ "section": "dashboard", "message": "Authenticated access granted." }`【F:routes/api.php†L72-L78】【F:app/Http/Controllers/Secure/SecurePageController.php†L12-L36】 |
+| `GET /api/secure/users` | Users area guard for client-side routing. | Meta section `"users"`.【F:routes/api.php†L79-L81】【F:app/Http/Controllers/Secure/SecurePageController.php†L16-L36】 |
+| `GET /api/secure/profile` | Profile management entry point. | Meta section `"profile"`.【F:routes/api.php†L82-L84】【F:app/Http/Controllers/Secure/SecurePageController.php†L18-L36】 |
+| `GET /api/secure/logs` | Ops/logs section placeholder. | Meta section `"logs"`.【F:routes/api.php†L85-L87】【F:app/Http/Controllers/Secure/SecurePageController.php†L20-L36】 |
+| `GET /api/secure/errors` | Error reporting section placeholder. | Meta section `"errors"`.【F:routes/api.php†L88-L90】【F:app/Http/Controllers/Secure/SecurePageController.php†L22-L36】 |
+
+### Front-end usage tips
+- Use these endpoints to confirm auth state during client-side navigation in Next.js (e.g., `useEffect` guard that fetches `/api/secure/dashboard`).
+- Because responses embed the authenticated user resource, you can hydrate global stores with profile data in one request.
+
+## 2. Admin resources
+All admin resources expose full RESTful endpoints via `Route::apiResource`. The tables below summarize validation rules so you can build the correct forms.
+
+### 2.1 Users
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/users` | Returns users with roles, teams, and profile eager-loaded.【F:routes/api.php†L91-L100】【F:app/Http/Controllers/Admin/UserController.php†L16-L23】 |
+| Create | `POST /api/admin/users` | Requires `name`, `email`, `password`. Accepts `roles` array, `teams` array of `{ id, role }`, and optional `profile` object.【F:app/Http/Controllers/Admin/UserController.php†L25-L73】 |
+| Show | `GET /api/admin/users/{id}` | Returns the user with relations.【F:app/Http/Controllers/Admin/UserController.php†L35-L39】 |
+| Update | `PUT/PATCH /api/admin/users/{id}` | Same payload as create but fields optional; password updates only when provided.【F:app/Http/Controllers/Admin/UserController.php†L41-L67】 |
+| Delete | `DELETE /api/admin/users/{id}` | Responds with `204` on success.【F:app/Http/Controllers/Admin/UserController.php†L69-L75】 |
+
+### 2.2 Roles
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/roles` | Returns roles with permissions eager-loaded.【F:app/Http/Controllers/Admin/RoleController.php†L17-L23】 |
+| Create | `POST /api/admin/roles` | Requires unique `name`; optional `display_name`, `description`, and `permissions` array of IDs.【F:app/Http/Controllers/Admin/RoleController.php†L25-L47】 |
+| Show | `GET /api/admin/roles/{id}` | Includes permissions relationship.【F:app/Http/Controllers/Admin/RoleController.php†L49-L53】 |
+| Update | `PUT/PATCH /api/admin/roles/{id}` | Same schema as create; syncing permissions when provided.【F:app/Http/Controllers/Admin/RoleController.php†L55-L76】 |
+| Delete | `DELETE /api/admin/roles/{id}` | Returns `204` after deletion.【F:app/Http/Controllers/Admin/RoleController.php†L78-L84】 |
+
+### 2.3 Permissions
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/permissions` | Returns ordered collection of permissions.【F:app/Http/Controllers/Admin/PermissionController.php†L17-L23】 |
+| Create | `POST /api/admin/permissions` | Requires unique `name`; optional `display_name`, `description`.【F:app/Http/Controllers/Admin/PermissionController.php†L25-L41】 |
+| Show | `GET /api/admin/permissions/{id}` | Returns the single permission object.【F:app/Http/Controllers/Admin/PermissionController.php†L43-L47】 |
+| Update | `PUT/PATCH /api/admin/permissions/{id}` | Optional fields with uniqueness checks on `name`.【F:app/Http/Controllers/Admin/PermissionController.php†L49-L63】 |
+| Delete | `DELETE /api/admin/permissions/{id}` | Returns `204` when removed.【F:app/Http/Controllers/Admin/PermissionController.php†L65-L71】 |
+
+### 2.4 Profiles
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/profiles` | Returns profiles with user relation eager-loaded.【F:app/Http/Controllers/Admin/ProfileController.php†L17-L23】 |
+| Create | `POST /api/admin/profiles` | Requires unique `user_id` plus optional name/phone/meta fields.【F:app/Http/Controllers/Admin/ProfileController.php†L25-L43】 |
+| Show | `GET /api/admin/profiles/{id}` | Returns the profile with user relation.【F:app/Http/Controllers/Admin/ProfileController.php†L35-L39】 |
+| Update | `PUT/PATCH /api/admin/profiles/{id}` | Same payload as create but fields optional; `user_id` remains unique.【F:app/Http/Controllers/Admin/ProfileController.php†L41-L63】 |
+| Delete | `DELETE /api/admin/profiles/{id}` | Returns `204` when deleted.【F:app/Http/Controllers/Admin/ProfileController.php†L65-L71】 |
+
+### 2.5 Teams
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/teams` | Returns teams with member relationships.【F:app/Http/Controllers/Admin/TeamController.php†L17-L23】 |
+| Create | `POST /api/admin/teams` | Requires unique `name`; accepts `description` and `members` array of `{ id, role }`.【F:app/Http/Controllers/Admin/TeamController.php†L25-L61】 |
+| Show | `GET /api/admin/teams/{id}` | Returns the team with members.【F:app/Http/Controllers/Admin/TeamController.php†L33-L37】 |
+| Update | `PUT/PATCH /api/admin/teams/{id}` | Same schema as create; updates relationships via sync.【F:app/Http/Controllers/Admin/TeamController.php†L39-L73】 |
+| Delete | `DELETE /api/admin/teams/{id}` | Returns `204` once removed.【F:app/Http/Controllers/Admin/TeamController.php†L75-L81】 |
+
+### 2.6 Settings
+| Operation | Path | Notes |
+| --- | --- | --- |
+| List | `GET /api/admin/settings` | Returns all settings ordered by key.【F:app/Http/Controllers/Admin/SettingController.php†L17-L23】 |
+| Create | `POST /api/admin/settings` | Requires unique `key`; accepts `value` and `type`.【F:app/Http/Controllers/Admin/SettingController.php†L25-L45】 |
+| Show | `GET /api/admin/settings/{id}` | Returns the setting object.【F:app/Http/Controllers/Admin/SettingController.php†L47-L51】 |
+| Update | `PUT/PATCH /api/admin/settings/{id}` | Same payload as create; validates uniqueness of `key`.【F:app/Http/Controllers/Admin/SettingController.php†L53-L71】 |
+| Delete | `DELETE /api/admin/settings/{id}` | Returns `204` when deleted.【F:app/Http/Controllers/Admin/SettingController.php†L73-L79】 |
+
+## 3. Front-end workflow suggestions
+1. //1.- Fetch the relevant list endpoint (e.g., `/api/admin/users`) on page load or via SWR/React Query to populate tables.
+2. //2.- Use the validation notes to build client-side schemas (e.g., Zod) so you can mirror backend rules and show inline errors.
+3. //3.- Submit mutations to the REST endpoints above and optimistically update the client cache when a `2xx` response is returned.
+4. //4.- Handle `401/419` responses by redirecting to your Next.js login flow and clearing stored tokens.

--- a/docs/frontend-integration/authentication/README.md
+++ b/docs/frontend-integration/authentication/README.md
@@ -1,0 +1,70 @@
+# Authentication Endpoints
+
+This document covers every endpoint under `/api/auth/*` so you can wire up registration, login, and token management flows in Next.js.
+
+## 1. Public registration and login
+| Method & Path | Middleware | Description | Response |
+| --- | --- | --- | --- |
+| `POST /api/auth/register` | `throttle:register` | Creates a new user via name, email, password payload. | Returns the created user resource and `201` on success.【F:routes/api.php†L25-L33】【F:app/Http/Controllers/Auth/RegisterController.php†L14-L31】 |
+| `POST /api/auth/login` | `throttle:login`, `web` | Email/password login that issues a session cookie. | Returns the authenticated user resource with a success meta message.【F:routes/api.php†L34-L41】【F:app/Http/Controllers/Auth/LoginController.php†L16-L63】 |
+
+### Required payload structure
+```json
+{
+  "name": "Jane Doe", // registration only
+  "email": "user@example.com",
+  "password": "secret-password",
+  "remember": true // optional flag for session login
+}
+```
+
+## 2. SPA session endpoints
+| Method & Path | Middleware | Purpose |
+| --- | --- | --- |
+| `POST /api/auth/session/login` | `throttle:login`, `web` | Issues a same-site session cookie for SPA requests.【F:routes/api.php†L37-L41】【F:app/Http/Controllers/Auth/SessionController.php†L15-L49】 |
+| `POST /api/auth/session/logout` | `web` | Logs out the current session and clears cookies.【F:routes/api.php†L42-L45】【F:app/Http/Controllers/Auth/SessionController.php†L51-L63】 |
+| `GET /api/auth/me` | `auth:sanctum` | Returns the authenticated user when a cookie or token is present.【F:routes/api.php†L58-L60】【F:app/Http/Controllers/Auth/SessionController.php†L65-L69】 |
+
+> **Next.js tip:** When using these endpoints from the browser, ensure requests include `credentials: 'include'` and the `X-XSRF-TOKEN` header.
+
+## 3. Personal access tokens
+| Method & Path | Middleware | Description |
+| --- | --- | --- |
+| `POST /api/auth/tokens` | `throttle:login` | Issues a new Sanctum token using email/password credentials. Pass `device_name` to label the token.【F:routes/api.php†L95-L100】【F:app/Http/Controllers/Auth/TokenController.php†L17-L52】 |
+| `GET /api/auth/tokens` | `auth:sanctum` | Lists the current user's tokens (id, name, timestamps).【F:routes/api.php†L64-L67】【F:app/Http/Controllers/Auth/TokenController.php†L54-L58】 |
+| `DELETE /api/auth/tokens/{id}` | `auth:sanctum` | Revokes a specific token by ID. Returns `404` if not found.【F:routes/api.php†L68-L71】【F:app/Http/Controllers/Auth/TokenController.php†L60-L71】 |
+
+### Token issuance payload
+```json
+{
+  "email": "user@example.com",
+  "password": "secret-password",
+  "device_name": "nextjs-ssr" // optional, defaults to user agent
+}
+```
+
+## 4. Passwordless options
+| Endpoint | Middleware | Notes |
+| --- | --- | --- |
+| `POST /api/auth/magic/request` | `web` | Stub endpoint to request a magic-link email. Customize the controller before production use.【F:routes/api.php†L44-L48】 |
+| `POST /api/auth/magic/verify` | `web` | Stub endpoint to verify magic links. Pair with your own token issuance logic.【F:routes/api.php†L49-L52】 |
+
+## 5. OAuth helpers
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /api/auth/oauth/redirect/{provider}` | Redirects the browser to the external OAuth provider (e.g., GitHub, Google).【F:routes/api.php†L53-L55】 |
+| `GET /api/auth/oauth/callback/{provider}` | Handles the provider callback. Extend the controller to create local users or tokens.【F:routes/api.php†L53-L55】 |
+
+## 6. WebAuthn support
+| Endpoint | Middleware | Description |
+| --- | --- | --- |
+| `POST /api/auth/webauthn/options` | none | Returns registration or authentication options for WebAuthn. Use this before invoking browser APIs.【F:routes/api.php†L56-L58】 |
+| `POST /api/auth/webauthn/register` | `auth:sanctum` | Registers a WebAuthn credential for the current user.【F:routes/api.php†L59-L61】 |
+| `POST /api/auth/webauthn/verify` | none | Verifies a WebAuthn assertion and should result in a login/session once implemented.【F:routes/api.php†L62-L63】 |
+
+## 7. JWKS discovery
+- `GET /api/auth/.well-known/jwks.json` responds with the JSON Web Key Set the API is configured to expose (empty by default). Use this when integrating OAuth/OIDC clients that expect JWKS metadata.【F:routes/api.php†L64-L66】
+
+## 8. Error handling expectations
+- Invalid credentials raise `422` validation errors for both session and token flows, so handle them with form-level validation states in Next.js.【F:app/Http/Controllers/Auth/LoginController.php†L35-L49】【F:app/Http/Controllers/Auth/TokenController.php†L24-L41】
+- Unverified emails trigger `403` responses prompting verification. Surface this status to users so they can resend verification emails.【F:app/Http/Controllers/Auth/LoginController.php†L50-L63】【F:app/Http/Controllers/Auth/SessionController.php†L33-L47】【F:app/Http/Controllers/Auth/TokenController.php†L30-L43】

--- a/docs/frontend-integration/setup/README.md
+++ b/docs/frontend-integration/setup/README.md
@@ -1,0 +1,42 @@
+# Next.js Integration Setup Checklist
+
+This guide summarizes the environment, middleware, and headers you need to configure when wiring a Next.js frontend to the Yamato Laravel API. Use it alongside the endpoint-specific guides.
+
+## 1. API host and health probe
+- **Base URL**: configure your Next.js API client with the Laravel base URL (e.g., `http://localhost:8000`).
+- **Health check**: `GET /api/health` returns `{ "ok": true }`, which you can use for readiness checks before enabling protected flows.【F:routes/api.php†L20-L22】
+
+## 2. Sanctum authentication modes
+Laravel Sanctum supports both bearer tokens and same-site cookies in this project.【F:routes/api.php†L56-L88】【F:routes/api.php†L95-L100】
+
+| Mode | Use case | Requirements |
+| --- | --- | --- |
+| **Bearer tokens** | Server-side rendering (SSR) calls from Next.js, or static site requests. | Issue tokens via `POST /api/auth/tokens` (see the authentication guide) and send `Authorization: Bearer <token>` on protected calls. |
+| **Cookie-based session** | Browser requests from the Next.js app when hosted on the same domain family. | Include your front-end domain(s) in `SANCTUM_STATEFUL_DOMAINS`, enable cross-site cookies when needed, and call the session login endpoint. |
+
+## 3. Environment variables to review
+Configure these Laravel variables so that cookies and OAuth flows align with the domains used by Next.js.
+
+| Variable | Purpose | Default / location |
+| --- | --- | --- |
+| `SANCTUM_STATEFUL_DOMAINS` | Comma-separated list of hosts that should receive Sanctum cookies. Must include every Next.js origin that uses cookie auth. | Defaults to local hosts plus the current app URL.【F:config/sanctum.php†L14-L23】 |
+| `SESSION_DRIVER` | Storage backend for cookie sessions. Default `database` ensures stateless frontends can share sessions across instances. | See `config/session.php` for default and alternatives.【F:config/session.php†L12-L25】 |
+| `SESSION_DOMAIN` | Root domain that issues cookies. Set it to your apex domain (e.g., `.example.com`) when sharing cookies between subdomains. | Controlled via `config/session.php`.【F:config/session.php†L62-L86】 |
+| `SESSION_SECURE_COOKIE` | Force HTTPS-only cookies in production. Enable (`true`) once your site is fully HTTPS. | Configured in `config/session.php`.【F:config/session.php†L88-L107】 |
+| `SESSION_SAME_SITE` | Adjust to `none` when the API and Next.js run on different domains and you need cross-site cookies. | See `config/session.php` comments for options.【F:config/session.php†L108-L124】 |
+| `APP_URL` | Used by Sanctum when computing first-party URLs. Set to the fully-qualified backend URL. | Referenced in `config/sanctum.php`.【F:config/sanctum.php†L14-L23】 |
+
+## 4. Middleware expectations
+- API endpoints that rely on session cookies require the `web` middleware in addition to Sanctum. Laravel already applies it on routes such as `/api/auth/session/*`; ensure your Next.js client sends the `X-XSRF-TOKEN` header extracted from the `XSRF-TOKEN` cookie when making POST/DELETE requests with cookies.
+- Bearer-protected endpoints are grouped under the `auth:sanctum` middleware. Confirm that your Next.js fetch helpers attach the bearer token when calling these routes.【F:routes/api.php†L56-L94】
+
+## 5. Database migrations for sessions
+Because the session driver defaults to `database`, run `php artisan migrate` so the `sessions` table exists before testing cookie logins.
+
+## 6. Cross-origin considerations
+- Laravel does not ship with an explicit CORS configuration file in this project. If you expose the API to browsers on a different origin, add the `Fruitcake\\Cors` middleware and define allowed origins via the `CORS_ALLOWED_ORIGINS` (custom) or by publishing `config/cors.php`.
+- When using `fetch` from Next.js on the client, remember to set `credentials: 'include'` for cookie-based auth.
+
+## 7. Suggested Next.js helpers
+- Create a shared API client that reads the base URL from an environment variable like `process.env.NEXT_PUBLIC_API_URL`.
+- Provide wrappers for `getServerSideProps`/`getStaticProps` that can inject bearer tokens from Next.js API routes when calling the Laravel backend.


### PR DESCRIPTION
## Summary
- add a setup checklist for connecting Next.js clients to the Laravel API
- document authentication endpoints and payload requirements for Sanctum flows
- map secure and admin API resources with validation notes for frontend forms

## Testing
- not run (documentation only)

------
https://chatgpt.com/codex/tasks/task_e_68de6f688dc08329ae07c8ed30a04205