### PR TITLE
Configure CORS for credentialed SPA logins

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+/vendor/
+/node_modules/
+.phpunit.result.cache

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Http\Middleware\HandleCors;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -12,7 +13,11 @@ return Application::configure(basePath: dirname(__DIR__))
         health: '/up',
     )
     ->withMiddleware(function (Middleware $middleware): void {
-        //
+        //1.- Attach the framework CORS middleware to API routes to emit specific origins for credentialed requests.
+        $middleware->appendToGroup('api', HandleCors::class);
+
+        //2.- Ensure web routes that power session-based authentication also include the tailored CORS headers.
+        $middleware->appendToGroup('web', HandleCors::class);
     })
     ->withExceptions(function (Exceptions $exceptions): void {
         //

--- a/config/cors.php
+++ b/config/cors.php
@@ -1,0 +1,32 @@
+<?php
+
+return [
+    //1.- Define the route patterns that should include CORS headers for SPA interactions.
+    'paths' => [
+        'api/*',
+        'sanctum/csrf-cookie',
+    ],
+
+    //2.- Allow every HTTP method so that preflight requests succeed without manual curation.
+    'allowed_methods' => ['*'],
+
+    //3.- Restrict origins to the configured frontend URL to support credentials instead of wildcards.
+    'allowed_origins' => [
+        env('APP_FRONTEND_URL', 'http://localhost:3000'),
+    ],
+
+    //4.- Keep pattern-based origins empty to avoid inadvertently permitting wildcards.
+    'allowed_origins_patterns' => [],
+
+    //5.- Permit any headers so the browser can send authentication information freely.
+    'allowed_headers' => ['*'],
+
+    //6.- Expose no additional headers by default to comply with credentialed request limitations.
+    'exposed_headers' => [],
+
+    //7.- Disable caching of preflight responses to honor dynamic configuration changes promptly.
+    'max_age' => 0,
+
+    //8.- Enable credential support so cookies and authorization headers are accepted cross-origin.
+    'supports_credentials' => true,
+];

--- a/tests/Feature/Cors/CorsHeadersTest.php
+++ b/tests/Feature/Cors/CorsHeadersTest.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace Tests\Feature\Cors;
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class CorsHeadersTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        //1.- Disable CSRF checks so the JSON login request can succeed inside the test harness.
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+
+        //2.- Apply the same origin configuration that production will use for SPA credential sharing.
+        config()->set('cors.allowed_origins', ['http://localhost:3000']);
+        config()->set('cors.supports_credentials', true);
+    }
+
+    public function test_login_response_uses_specific_origin_header(): void
+    {
+        //1.- Create a verified user with a known password to authenticate against the API route.
+        $user = User::factory()->create([
+            'email' => 'spa@example.com',
+            'password' => Hash::make('Password123!'),
+        ]);
+
+        //2.- Exercise the login endpoint with the SPA origin header to trigger the CORS middleware.
+        $response = $this->withHeaders([
+            'Origin' => 'http://localhost:3000',
+        ])->postJson('/api/auth/login', [
+            'email' => $user->email,
+            'password' => 'Password123!',
+        ]);
+
+        //3.- Assert the response succeeded and exposes the specific CORS headers required for credentialed requests.
+        $response->assertOk();
+        $this->assertSame('http://localhost:3000', $response->headers->get('Access-Control-Allow-Origin'));
+        $this->assertSame('true', $response->headers->get('Access-Control-Allow-Credentials'));
+    }
+}


### PR DESCRIPTION
## Summary
- add a dedicated CORS configuration that limits origins to the configured frontend URL while supporting credentials
- register the framework CORS middleware on API and web route groups to emit specific origins instead of wildcards
- cover the login flow with a feature test that asserts the Access-Control headers when requests originate from the SPA

## Testing
- `composer test`


------
https://chatgpt.com/codex/tasks/task_e_68e905bb6cf08329965360da83106de6